### PR TITLE
Handles case when track's preview_url isn't available

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -69,7 +69,9 @@ export class AppComponent implements OnDestroy {
   playTrack(track: Track) {
     if (this.track && this.track.id === track.id) { return; }
     this.track = track;
-    this.spotifyAudio.playAudioTrack(track.preview_url)
+    if (track.preview_url) {
+      this.spotifyAudio.playAudioTrack(track.preview_url);
+    }
   }
 
   closeModal() {

--- a/src/app/components/spotify/track-list.component.ts
+++ b/src/app/components/spotify/track-list.component.ts
@@ -18,6 +18,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
             *ngFor="let t of album.tracks.items; let i = index"
             (click)="trackClick.emit(t)"
             [style.color]="t.id === track?.id ? 'orange' : null"
+            [style.color]="t.preview_url === null ? 'red' : null"
             >
             {{i+1}}. {{t.name}} - {{t.duration_ms | secsToTime: true}} 
           </div>


### PR DESCRIPTION
Great work on the app! 👍 Definitely a neat demo, just thought I could PR back what I fixed locally. 

In the Spotify documentation, it states that the preview_url field can sometimes be [null](https://developer.spotify.com/documentation/web-api/reference/search/search/) (whenever the preview_url isn't available). The app currently encounters an error whenever a user selects a track without a preview available (ie. any of Taylor Swift's songs haha). I've handled that case so it will only try to play the track if it's available in the first place. I also made the track color red if you can't play it, so it's easier to distinguish from a UI perspective. :) 